### PR TITLE
[WIP] README: Add a reference to Ansible Collection Checklist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,7 @@ Documentation
 
 * `Using Ansible Collections <https://docs.ansible.com/ansible/latest/user_guide/collections_using.html>`_
 * `Developing Collections <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html>`_
+* `Ansible Collections Checklist <https://github.com/ansible-collections/overview/blob/master/collection_requirements.rst>`_
 
 Work needed
 ===========

--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,8 @@ Contributors to Ansible
 
 `Developing Collections <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html>`_
 
+`Ansible Collections Checklist <https://github.com/ansible-collections/overview/blob/master/collection_requirements.rst>`_
+
 Q: I'd like to submit a new module or plugin to Ansible. How shall I proceed?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
##### SUMMARY
I haven't found Ansible Collection Checklist on the doc site. Seems that it's not there yet.
Until that, would be good to have a reference to the file in README. Later we could change it to a corresponding doc page.

##### ISSUE TYPE
- Docs Pull Request
