### PR TITLE
Validate RST files

### DIFF
--- a/.github/workflows/rstlint.yml
+++ b/.github/workflows/rstlint.yml
@@ -1,5 +1,4 @@
-#https://github.com/OskarStark/doctor-rst
-
+---
 on: [push, pull_request]
 name: Lint
 jobs:

--- a/.github/workflows/rstlint.yml
+++ b/.github/workflows/rstlint.yml
@@ -1,0 +1,23 @@
+#https://github.com/OskarStark/doctor-rst
+
+on: [push, pull_request]
+name: Lint
+jobs:
+  rstcheck:
+    name: Validate rst
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+            sudo apt-get install python3-setuptools
+            sudo python -m pip install --upgrade pip
+            sudo pip install rstcheck
+
+      - name: run rstcheck
+        run: rstcheck --report error *.rst

--- a/status.rst
+++ b/status.rst
@@ -153,7 +153,3 @@ A list of items can be found in the `Community Collection Project Board <https:/
 
 Limitations and known issues
 ============================
-
-
-incorrect
-~~~~~~~~~

--- a/status.rst
+++ b/status.rst
@@ -91,7 +91,6 @@ ACD Proposal
 FIXME: Link to proposal
 
 
-
 Automatic push to Galaxy on Git tag
 -----------------------------------
 
@@ -140,7 +139,6 @@ The main pending documentation changes include:
 * Update user/developer guides to reflect collections now.
 
 
-
 The other documentation issues related to collections on docs.ansible.com are being tracked with the `docs and collections labels
 <https://github.com/ansible/ansible/issues?q=is%3Aopen+is%3Aissue+label%3Adocs+label%3Acollection>`_.
 
@@ -155,3 +153,7 @@ A list of items can be found in the `Community Collection Project Board <https:/
 
 Limitations and known issues
 ============================
+
+
+incorrect
+~~~~~~~~~


### PR DESCRIPTION
##### SUMMARY
Validate RST files

Add basic validation as occasionally GitHub was only showing the raw RST text due to errors such as incorrect headings.

##### ISSUE TYPE
- Feature Pull Request
