### PR TITLE
BSD License for module_utils should be 2 clause

### DIFF
--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -143,7 +143,7 @@ We should avoid FQCN / repository names:
 Licensing
 =========
 
-At the moment, module_utils must be licensed under the BSD-2-clause or GPLv3+ license and all other content must be licensed under the GPLv3+.  We will have a list of other open source licenses which are allowed as soon as we get Red Hat's legal team to approve such a list for us.
+At the moment, module_utils must be licensed under the `BSD-2-clause <https://opensource.org/licenses/BSD-2-Clause>`_ or `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_ license and all other content must be licensed under the `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  We will have a list of other open source licenses which are allowed as soon as we get Red Hat's legal team to approve such a list for us.
 
 
 Repository management

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -143,7 +143,7 @@ We should avoid FQCN / repository names:
 Licensing
 =========
 
-At the moment, module_utils must be licensed under the BSD-3-clause or GPLv3+ license and all other content must be licensed under the GPLv3+.  We will have a list of other open source licenses which are allowed as soon as we get Red Hat's legal team to approve such a list for us.
+At the moment, module_utils must be licensed under the BSD-2-clause or GPLv3+ license and all other content must be licensed under the GPLv3+.  We will have a list of other open source licenses which are allowed as soon as we get Red Hat's legal team to approve such a list for us.
 
 
 Repository management


### PR DESCRIPTION
The current ansible module_utils are actually under the BSD-2-clause license, not the BSD-3-clause license.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
