### PR TITLE
List of unacceptable values for new entries in ignore files

### DIFF
--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -180,8 +180,9 @@ CI Testing
 * The sanity tests MUST pass.
 
   * Adding some entries to the ``test/sanity/ignore*.txt`` file is an allowed method of getting them to pass, except cases listed below.
+  * You SHOULD not have ignored test entries.  A reviewer can manually evaluate and approve your collection if they deem an ignored entry to be valid.
 
-  * You MUST not add the following entries to ``test/sanity/ignore*.txt`` files, for the sake of documentation completeness and accuracy:
+  * You MUST not ignore the following validations. They must be fixed before approval:
       * ``validate-modules:doc-choices-do-not-match-spec``
       * ``validate-modules:doc-default-does-not-match-spec``
       * ``validate-modules:doc-missing-type``

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -179,7 +179,7 @@ CI Testing
 * You SHOULD suggest to *additionally* run ``ansible-test sanity`` from the ansible/ansible ``devel`` branch so that you find out about new linting requirements earlier.
 * The sanity tests MUST pass.
 
-  * Adding some entries to the ``test/sanity/ignore*.txt`` file is an allowed method of getting them to pass., except cases listed below.
+  * Adding some entries to the ``test/sanity/ignore*.txt`` file is an allowed method of getting them to pass, except cases listed below.
 
   * You MUST not add the following entries to ``test/sanity/ignore*.txt`` files, for the sake of documentation completeness and accuracy:
       * validate-modules:doc-choices-do-not-match-spec

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -174,17 +174,29 @@ Branch protections MUST be enforced:
 CI Testing
 ===========
 
-* You MUST run ``ansible-test sanity`` from the `latest stable ansible-base/ansible-core branch <https://github.com/ansible/ansible/branches/all?query=stable->`_. 
+* You MUST run ``ansible-test sanity`` from the `latest stable ansible-base/ansible-core branch <https://github.com/ansible/ansible/branches/all?query=stable->`_.
 * You MUST run CI against all versions of ``ansible-base``/``ansible-core`` that the collection supports.
 * You SHOULD suggest to *additionally* run ``ansible-test sanity`` from the ansible/ansible ``devel`` branch so that you find out about new linting requirements earlier.
 * The sanity tests MUST pass.
 
-  * Adding some entries to the ``test/sanity/ignore*.txt`` file is an allowed method of getting them to pass. 
+  * Adding some entries to the ``test/sanity/ignore*.txt`` file is an allowed method of getting them to pass., except cases listed below.
+
+  * You MUST not add the following entries to ``test/sanity/ignore*.txt`` files, for the sake of documentation completeness and accuracy:
+      * validate-modules:doc-choices-do-not-match-spec
+      * validate-modules:doc-default-does-not-match-spec
+      * validate-modules:doc-missing-type
+      * validate-modules:doc-required-mismatch
+      * validate-modules:mutually_exclusive-unknown
+      * validate-modules:nonexistent-parameter-documented
+      * validate-modules:parameter-list-no-elements
+      * validate-modules:parameter-type-not-in-doc
+      * validate-modules:undocumented-parameter
+
   * All entries in ignores.txt MUST have a justification in a comment in the ignore.txt file for each entry.  For example ``plugins/modules/docker_container.py use-argspec-type-path # uses colon-separated paths, can't use type=path``.
   * Reviewers can block acceptance of a new collection if they don't agree with the ignores.txt entries.
 
 * All CI tests MUST run against every PR & commit to the repo.
-* All CI tests MUST run regularly (nightly, or at least once per week) to ensure that repos without regular commits are tested against the latest version of ansible-test from each ansible-base/ansible-core version tested. 
+* All CI tests MUST run regularly (nightly, or at least once per week) to ensure that repos without regular commits are tested against the latest version of ansible-test from each ansible-base/ansible-core version tested.
 
 All of the above can be achieved by using the following GitHub Action template, see `example <https://github.com/ansible-collections/collection_template/tree/main/.github/workflows>`_.
 

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -182,15 +182,15 @@ CI Testing
   * Adding some entries to the ``test/sanity/ignore*.txt`` file is an allowed method of getting them to pass, except cases listed below.
 
   * You MUST not add the following entries to ``test/sanity/ignore*.txt`` files, for the sake of documentation completeness and accuracy:
-      * validate-modules:doc-choices-do-not-match-spec
-      * validate-modules:doc-default-does-not-match-spec
-      * validate-modules:doc-missing-type
-      * validate-modules:doc-required-mismatch
-      * validate-modules:mutually_exclusive-unknown
-      * validate-modules:nonexistent-parameter-documented
-      * validate-modules:parameter-list-no-elements
-      * validate-modules:parameter-type-not-in-doc
-      * validate-modules:undocumented-parameter
+      * ``validate-modules:doc-choices-do-not-match-spec``
+      * ``validate-modules:doc-default-does-not-match-spec``
+      * ``validate-modules:doc-missing-type``
+      * ``validate-modules:doc-required-mismatch``
+      * ``validate-modules:mutually_exclusive-unknown``
+      * ``validate-modules:nonexistent-parameter-documented``
+      * ``validate-modules:parameter-list-no-elements``
+      * ``validate-modules:parameter-type-not-in-doc``
+      * ``validate-modules:undocumented-parameter``
 
   * All entries in ignores.txt MUST have a justification in a comment in the ignore.txt file for each entry.  For example ``plugins/modules/docker_container.py use-argspec-type-path # uses colon-separated paths, can't use type=path``.
   * Reviewers can block acceptance of a new collection if they don't agree with the ignores.txt entries.


### PR DESCRIPTION
##### SUMMARY
Suggestion of unacceptable entries for ignore files, per comment:
https://github.com/ansible-collections/overview/pull/132\#discussion_r539635888

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
collection_requirements.rst

##### ADDITIONAL INFORMATION
As of today (Dec 13, 2020), the rank of ignore entries' types is (for ``tests/sanity/ignore-2.10.txt``):
```
$ ../sort-ignores tests/sanity/ignore-2.10.txt
    129 validate-modules:parameter-list-no-elements
     87 validate-modules:parameter-type-not-in-doc
     84 validate-modules:doc-missing-type
     53 validate-modules:undocumented-parameter
     27 pylint:blacklisted-name
     23 validate-modules:return-syntax-error
     22 validate-modules:invalid-ansiblemodule-schema
     21 validate-modules:doc-default-does-not-match-spec
     11 validate-modules:parameter-state-invalid-choice
     11 validate-modules:parameter-invalid
      7 validate-modules:mutually_exclusive-unknown
      7 use-argspec-type-path
      6 validate-modules:doc-required-mismatch
      4 validate-modules:invalid-argument-name
      3 validate-modules:doc-choices-do-not-match-spec
      2 validate-modules:missing-suboption-docs
      1 yamllint:unparsable-with-libyaml
      1 validate-modules:use-run-command-not-popen
      1 validate-modules:nonexistent-parameter-documented
      1 validate-modules:no-default-for-required-parameter
      1 shebang
      1 replace-urlopen
      1 pylint:ansible-bad-function
      1 no-unicode-literals
      1 no-assert
      1 metaclass-boilerplate
      1 future-import-boilerplate
```