### PR TITLE
The repository management subsection is for gh.com/ansible-collections

### DIFF
--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -163,7 +163,9 @@ Repository management
 Branch name and configuration
 -----------------------------
 
-All new repositories under `ansible-collections <https://github.com/ansible-collections>`_ MUST have ``main`` as the default branch.
+This subsection is **only** for repositories under `ansible-collections <https://github.com/ansible-collections>`_! Other collection repositories can also follow these guidelines, but do not have to.
+
+All new repositories MUST have ``main`` as the default branch.
 
 Existing repositories SHOULD be converted to use ``main``
 


### PR DESCRIPTION
##### SUMMARY
Make it clearer that repo management subsection is only about gh.com/ansible-collections.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
collection_requirements.rst
