### PR TITLE
Add clarification about objects inside collection Galaxy artifacts

### DIFF
--- a/collection_checklist.md
+++ b/collection_checklist.md
@@ -28,7 +28,8 @@ Every comment should say whether the reviewer expects it to be addressed, or whe
 - [ ] collection dependencies must have a lower bound on the version which is at least 1.0.0, and are all part of the `ansible` package
 - [ ] `meta/runtime.yml` defines the minimal version of Ansible which the collection works with
 - [ ] has changelog, preferably with `changelogs/changelog.yaml`
-- [ ] `tests/integration/` does not contain any package installers (binaries, tarballs, archives, and so on) and other large objects used for integration tests
+- [ ] collection Galaxy artifact (tarball) should not contain any large objects (binaries) comparatively to the current tarball size limit of 20 MB
+- [ ] if a collection Galaxy artifact contains objects mentioned above, they must follow [licensing rules](https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#licensing)
 
 **Tests:**
 - [ ] passed `ansible-test sanity`

--- a/collection_checklist.md
+++ b/collection_checklist.md
@@ -28,6 +28,7 @@ Every comment should say whether the reviewer expects it to be addressed, or whe
 - [ ] collection dependencies must have a lower bound on the version which is at least 1.0.0, and are all part of the `ansible` package
 - [ ] `meta/runtime.yml` defines the minimal version of Ansible which the collection works with
 - [ ] has changelog, preferably with `changelogs/changelog.yaml`
+- [ ] `tests/integration/` does not contain any package installers (binaries, tarballs, archives, and so on) and other large objects used for integration tests
 
 **Tests:**
 - [ ] passed `ansible-test sanity`

--- a/collection_checklist.md
+++ b/collection_checklist.md
@@ -29,7 +29,7 @@ Every comment should say whether the reviewer expects it to be addressed, or whe
 - [ ] `meta/runtime.yml` defines the minimal version of Ansible which the collection works with
 - [ ] has changelog, preferably with `changelogs/changelog.yaml`
 - [ ] collection Galaxy artifact (tarball) should not contain any large objects (binaries) comparatively to the current tarball size limit of 20 MB
-- [ ] if a collection Galaxy artifact contains objects mentioned above, they must follow [licensing rules](https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#licensing)
+- [ ] any objects in a collection Galaxy artifact including the mentioned above must follow [licensing rules](https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#licensing)
 
 **Tests:**
 - [ ] passed `ansible-test sanity`

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -96,10 +96,13 @@ Modules & Plugins
   The core team (which maintains ansible-core) has committed not to use these directories for
   anything which would conflict with the uses we've specified.
 
-test/integration
-----------------
+Collection artifacts
+--------------------
 
-* MUST NOT contain any package installers (binaries, archives, tarballs, and so on) and other large files used, in particular, for integration tests.
+Collection Galaxy artifacts (tarballs):
+
+* SHOULD NOT contain any large objects (binaries) comparatively to the tarball size limit of 20 MB. If you need to include such files in your collection repository, make sure to exclude them from the collection build and, if a purpose of presence is testing, make sure that your tests also work without the files (for example, by loading them from a remote repository)
+* MUST contain objects that follow :ref:`licensing rules <Licensing>`
 
 
 Documentation
@@ -172,6 +175,7 @@ We should avoid FQCN / repository names:
 * which are unnecessary long: try to make it compact but clear
 * contain the same words / collocations in ``NAMESPACE`` and ``COLLECTION`` parts, for example ``my_system.my_system``
 
+.. _Licensing:
 
 Licensing
 =========

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -39,11 +39,11 @@ Collection Infrastructure
 =========================
 
 * MUST have a publicly available issue tracker, that does not require a paid level of service to create an account or view issues.
-* Collections MUST have a Code of Conduct (CoC)
+* Collections MUST have a Code of Conduct (CoC).
 
-  * The collection's CoC MUST be compatible with the Ansible CoC
-  * Collections SHOULD consider using the Ansible CoC if they do not have a CoC that they consider better
-  * The Diversity and Inclusion working group may evaluate all CoCs and object to a collection's inclusion based on the CoCs contents
+  * The collection's CoC MUST be compatible with the Ansible CoC.
+  * Collections SHOULD consider using the Ansible CoC if they do not have a CoC that they consider better.
+  * The Diversity and Inclusion working group may evaluate all CoCs and object to a collection's inclusion based on the CoCs contents.
   * The CoC must be linked from the README.md file, or must be present or linked from a CODE_OF_CONDUCT.md file in the collection root.
   
 * MUST be published to `Ansible Galaxy <https://galaxy.ansible.com>`_.
@@ -78,10 +78,10 @@ meta/runtime.yml
 ----------------
 Example: `meta/runtime.yml <https://github.com/ansible-collections/collection_template/blob/main/meta/runtime.yml>`_
 
-* MUST define the minimum version of Ansible which this collection works with
+* MUST define the minimum version of Ansible which this collection works with.
 
-  * If the collection works with Ansible 2.9, then this should be set to `>=2.9.10`
-  * It's usually better to avoid adding `<2.11` as a restriction, since this for example makes it impossible to use the collection with the current ansible-base devel branch (which has version 2.11.0.dev0)
+  * If the collection works with Ansible 2.9, then this should be set to `>=2.9.10`.
+  * It's usually better to avoid adding `<2.11` as a restriction, since this for example makes it impossible to use the collection with the current ansible-base devel branch (which has version 2.11.0.dev0).
 
 Modules & Plugins
 ------------------
@@ -95,6 +95,11 @@ Modules & Plugins
 
   The core team (which maintains ansible-core) has committed not to use these directories for
   anything which would conflict with the uses we've specified.
+
+test/integration
+----------------
+
+* MUST NOT contain any package installers (binaries, archives, tarballs, and so on) and other large files used, in particular, for integration tests.
 
 
 Documentation

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -101,8 +101,8 @@ Collection artifacts
 
 Collection Galaxy artifacts (tarballs):
 
-* SHOULD NOT contain any large objects (binaries) comparatively to the tarball size limit of 20 MB. If you need to include such files in your collection repository, make sure to exclude them from the collection build and, if a purpose of presence is testing, make sure that your tests also work without the files (for example, by loading them from a remote repository)
-* MUST contain objects that follow :ref:`licensing rules <Licensing>`
+* SHOULD NOT contain any large objects (binaries) comparatively to the tarball size limit of 20 MB. If you need to include such files in your collection repository, make sure to exclude them from the collection build and, if a purpose of presence is testing, make sure that your tests also work without the files (for example, by loading them from a remote repository).
+* MUST only contain objects that follow the :ref:`licensing rules <Licensing>`.
 
 
 Documentation


### PR DESCRIPTION
##### SUMMARY
Add clarification about objects inside collection Galaxy artifacts
The current collection tarball size limit to upload to galaxy is 20MB.
When a number of collection increases, it can affect Ansible distribution size significantly.

https://github.com/ansible/community/issues/539