### PR TITLE
Collection guidelines: disallow validate-modules:no-log-needed ignore.txt entries

### DIFF
--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -216,6 +216,7 @@ CI Testing
       * ``validate-modules:doc-missing-type``
       * ``validate-modules:doc-required-mismatch``
       * ``validate-modules:mutually_exclusive-unknown``
+      * ``validate-modules:no-log-needed`` (use ``no_log=False`` in the argument spec to flag false positives!)
       * ``validate-modules:nonexistent-parameter-documented``
       * ``validate-modules:parameter-list-no-elements``
       * ``validate-modules:parameter-type-not-in-doc``


### PR DESCRIPTION
##### SUMMARY
Now that ansible/ansible#73508 landed in devel's sanity tests, it is mandatory that collections mark false positives with `no_log=False` in the argument spec and **NOT** simply ignore `no-log-needed` for a module file.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
collection_requirements.rst
