### PR TITLE
Expand the licenses allowed in collections

### DIFF
--- a/collection_checklist.md
+++ b/collection_checklist.md
@@ -13,7 +13,7 @@ Every comment should say whether the reviewer expects it to be addressed, or whe
 
 **Standards and documentation:**
 - [ ] adheres to [semantic versioning](https://semver.org/)
-- [ ] follows licensing rules
+- [ ] follows [licensing rules](https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#licensing)
 - [ ] follows the [Ansible documentation standards](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html) and the [style guide](https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#style-guide)
 - [ ] follows [development conventions](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_best_practices.html)
 - [ ] supports Python 2.6 or greater and Python 3.5 or greater. If it does not, read the [full guidelines](https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#python-compatibility) to see if you qualify for an exception and document the unsupported [Python versions](https://docs.ansible.com/ansible/latest/dev_guide/developing_python_3.html#ansible-and-python-3) in the collection ``README.md`` and in every module and plugin (or in doc fragments)

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -220,25 +220,30 @@ Licensing
 **Note**: The guidelines below are more restrictive than strictly necessary.  We will try to add
 a larger list of acceptable licenses once we have approval from Red Hat Legal.
 
-There are three types of plugin code in collections which licensing has to address in different
+There are four types of content in collections which licensing has to address in different
 ways:
 
-:modules: must be licensed compatibly with the `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_
-:module_utils: must be licensed compatibly with the `GPL-3.0-or-later
-               <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  Ansible itself typically
-               uses the `BSD-2-clause <https://opensource.org/licenses/BSD-2-Clause>`_ license to
-               make it possible for third-party modules which are licensed incompatibly with the
-               GPLv3 to use them.  Please consider this use case when licensing your own
-               ``module_utils``.
-:All other plugin code: All other code must be under the `GPL-3.0-or-later
+:modules: must be licensed with a free software license that is compatible with the
+          `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_
+:module_utils: must be licensed with a free software license that is compatible with the
+               `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  Ansible
+               itself typically uses the `BSD-2-clause
+               <https://opensource.org/licenses/BSD-2-Clause>`_ license to make it possible for
+               third-party modules which are licensed incompatibly with the GPLv3 to use them.
+               Please consider this use case when licensing your own ``module_utils``.
+:All other code: All other code must be under the `GPL-3.0-or-later
                  <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins are run
                  inside of the Ansible controller process which is licensed under the GPLv3+ and
                  often must import code from the controller.  For these reasons, the GPLv3+ must be
                  used.
+:Non code content: At the moment, these must also be under the `GPL-3.0-or-later       
+                   <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
 
-Please use `this table of licenses from the Fedora Project
+Use `this table of licenses from the Fedora Project
 <https://fedoraproject.org/wiki/Licensing:Main#Software_License_List>`_ to find which licenses are
-compatible with the GPLv3+.
+compatible with the GPLv3+.  The license must be considered open source on both the Fedora License
+table and the `Debian Free Software Guidelines <https://wiki.debian.org/DFSGLicenses>`_ to be
+allowed.
 
 These guidelines are the policy for inclusion in the Ansible package and are in addition to any
 licensing and legal concerns that may otherwise affect your code.

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -226,9 +226,10 @@ ways:
 :modules: must be licensed compatibly with the `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_
 :module_utils: must be licensed compatibly with the `GPL-3.0-or-later
                <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  Ansible itself typically
-               `BSD-2-clause <https://opensource.org/licenses/BSD-2-Clause>`_ to make it possible
-               for third-party modules which are licensed incompatibly with the GPLv3 to use them.
-               Please consider this use case when licensing your own ``module_utils``.
+               uses the `BSD-2-clause <https://opensource.org/licenses/BSD-2-Clause>`_ license to
+               make it possible for third-party modules which are licensed incompatibly with the
+               GPLv3 to use them.  Please consider this use case when licensing your own
+               ``module_utils``.
 :All other plugin code: All other code must be under the `GPL-3.0-or-later
                  <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins are run
                  inside of the Ansible controller process which is licensed under the GPLv3+ and

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -217,7 +217,30 @@ We should avoid FQCN / repository names:
 Licensing
 =========
 
-At the moment, ``module_utils`` must be licensed under the `BSD-2-clause <https://opensource.org/licenses/BSD-2-Clause>`_ or `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_ license and all other content must be licensed under the `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  We will have a list of other open source licenses which are allowed as soon as we get Red Hat's legal team to approve such a list for us.
+**Note**: The guidelines below are more restrictive than strictly necessary.  We will try to add
+a larger list of acceptable licenses once we have approval from Red Hat Legal.
+
+There are three types of plugin code in collections which licensing has to address in different
+ways:
+
+:modules: must be licensed compatibly with the `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_
+:module_utils: must be licensed compatibly with the `GPL-3.0-or-later
+               <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  Ansible itself typically
+               `BSD-2-clause <https://opensource.org/licenses/BSD-2-Clause>`_ to make it possible
+               for third-party modules which are licensed incompatibly with the GPLv3 to use them.
+               Please consider this use case when licensing your own ``module_utils``.
+:All other plugin code: All other code must be under the `GPL-3.0-or-later
+                 <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins are run
+                 inside of the Ansible controller process which is licensed under the GPLv3+ and
+                 often must import code from the controller.  For these reasons, the GPLv3+ must be
+                 used.
+
+Please use `this table of licenses from the Fedora Project
+<https://fedoraproject.org/wiki/Licensing:Main#Software_License_List>`_ to find which licenses are
+compatible with the GPLv3+.
+
+These guidelines are the policy for inclusion in the Ansible package and are in addition to any
+licensing and legal concerns that may otherwise affect your code.
 
 
 Repository management


### PR DESCRIPTION
Allow modules and module_utils to use licenses that are compatible with
the GPLv3+ rather than restricting them to only the GPLv3+.

This is to address the issue raised here: https://github.com/ansible-community/community-topics/issues/2

(Allowing a collection with modules licensed under Apache v2)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->t
- Docs Pull Request

