### PR TITLE
Describe how collections can be removed from the Ansible package

### DIFF
--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -157,4 +157,4 @@ Process
 Re-adding collection to Ansible
 -------------------------------
 
-There is no simplified process. Once the collection has been removed from Ansible Y.0.0, it needs to go through the full inclusion process to be re-added to the Ansible package. Exceptions are only possible if the Steering Committee votes on them, and it is in the discretion of the Steering Committee to deny a fast re-entry without going through the full review process.
+There is no simplified process. Once the collection has been removed from Ansible Y.0.0, it needs to go through the full inclusion process to be re-added to the Ansible package. Exceptions are only possible if the Steering Committee votes on them. The Steering Committee can approve or deny a fast re-entry without going through the full review process.

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -81,8 +81,8 @@ Process
 
 The announcement mentioned below must state the reasons for the proposed removal and alert maintainers and the Ansible community that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
 
-#. Announce upcoming removal in Ansible X+1 as described in :ref:`announce_removal`.
-#. Remove collection from Ansible X+1 as described in :ref:`remove_collection`.
+#. `Announce upcoming removal in Ansible X+1 <announce_removal>`_.
+#. `Remove collection from Ansible X+1 <remove_collection>`_.
 
 Cancelling removal of a broken collection
 -----------------------------------------
@@ -98,7 +98,7 @@ Process
 
 #. Update the removal issue in the collection's issue tracker and close the issue.
 #. Announce cancelled removal in The Bullhorn.
-#. Re-add collection to Ansible X+1 as described in :ref:`readd_collection`.
+#. `Re-add collection to Ansible X+1 <readd_collection>`_.
 
 Re-adding collection to Ansible
 -------------------------------
@@ -140,8 +140,8 @@ Process
 #. At least four weeks after the notice appeared in The Bullhorn and the collection's issue tracker, the Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. The vote must be open for at least one week.
 #. If the SC does not votes that the collection seems to be unmaintained, the process is stopped. The issue needs to be updated accordingly.
 #. If X.0.0 will be released next, set Y=X+1. If X.0.0 has already been released, but (X+1).0.0 has not yet been released, set Y=X+2.
-#. Announce upcoming removal from Ansible Y as described in :ref:`announce_removal`.
-#. Remove collection from Ansible Y as described in :ref:`remove_collection`.
+#. `Announce upcoming removal from Ansible Y <announce_removal>`_.
+#. `Remove collection from Ansible Y <remove_collection>`_.
 
 Cancelling removal of an unmaintained collection
 ------------------------------------------------
@@ -159,7 +159,7 @@ Process
 #. The Steering Committee votes on whether the result is acceptable.
 #. A negative vote must come with a good explanation why the clean up work has not been sufficient. In that case, this process stops.
 #. If the Steering Committee does not vote against still removing the collection (this includes the case that the vote did not reach quorum), proceed as follows.
-#. Re-add collection to Ansible Y as described in :ref:`readd_collection`.
+#. `Re-add collection to Ansible Y <readd_collection>`_.
 
 Re-adding collection to Ansible
 -------------------------------

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -81,8 +81,8 @@ Process
 
 The announcement mentioned below must state the reasons for the proposed removal and alert maintainers and the Ansible community that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
 
-#. `Announce upcoming removal in Ansible X+1 <announce_removal>`_.
-#. `Remove collection from Ansible X+1 <remove_collection>`_.
+#. `Announce upcoming removal in Ansible X+1 <announce_removal_>`_.
+#. `Remove collection from Ansible X+1 <remove_collection_>`_.
 
 Cancelling removal of a broken collection
 -----------------------------------------
@@ -98,7 +98,7 @@ Process
 
 #. Update the removal issue in the collection's issue tracker and close the issue.
 #. Announce cancelled removal in The Bullhorn.
-#. `Re-add collection to Ansible X+1 <readd_collection>`_.
+#. `Re-add collection to Ansible X+1 <readd_collection_>`_.
 
 Re-adding collection to Ansible
 -------------------------------
@@ -140,8 +140,8 @@ Process
 #. At least four weeks after the notice appeared in The Bullhorn and the collection's issue tracker, the Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. The vote must be open for at least one week.
 #. If the SC does not votes that the collection seems to be unmaintained, the process is stopped. The issue needs to be updated accordingly.
 #. If X.0.0 will be released next, set Y=X+1. If X.0.0 has already been released, but (X+1).0.0 has not yet been released, set Y=X+2.
-#. `Announce upcoming removal from Ansible Y <announce_removal>`_.
-#. `Remove collection from Ansible Y <remove_collection>`_.
+#. `Announce upcoming removal from Ansible Y <announce_removal_>`_.
+#. `Remove collection from Ansible Y <remove_collection_>`_.
 
 Cancelling removal of an unmaintained collection
 ------------------------------------------------
@@ -159,7 +159,7 @@ Process
 #. The Steering Committee votes on whether the result is acceptable.
 #. A negative vote must come with a good explanation why the clean up work has not been sufficient. In that case, this process stops.
 #. If the Steering Committee does not vote against still removing the collection (this includes the case that the vote did not reach quorum), proceed as follows.
-#. `Re-add collection to Ansible Y <readd_collection>`_.
+#. `Re-add collection to Ansible Y <readd_collection_>`_.
 
 Re-adding collection to Ansible
 -------------------------------

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -11,6 +11,44 @@ Sometimes the Ansible community removes a collection from the Ansible package. W
 
 In cases of emergency (for example, a serious security vulnerability that is not fixed in a collection) the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions. In most cases, we follow the rules listed on this page.
 
+General processes
+=================
+
+This section describes some general processes that will be referred to below.
+
+_announce_removal:
+
+Announcing upcoming removal
+---------------------------
+
+#. Announce upcoming removal in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``).
+   See the following link for an `example on how to add changelog entries to the Ansible changelog <https://github.com/ansible-community/ansible-build-data/pull/68/files>`__.
+#. Announce upcoming removal in the collection's issue tracker.
+#. Announce upcoming removal in The Bullhorn.
+
+_remove_collection:
+
+Removing a collection
+---------------------
+
+To remove a collection from Ansible version X.0.0:
+
+#. Remove from ``ansible.in`` (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/ansible.in``).
+#. Remove from ``collection-meta.yaml`` (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/collection-meta.yaml``).
+#. Document actual removal for the first/next alpha of Ansible X.0.0 in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``).
+   See the following link for an `example on how to add changelog entries to the Ansible changelog <https://github.com/ansible-community/ansible-build-data/pull/68/files>`__.
+
+_readd_collection:
+
+Re-adding a collection
+----------------------
+
+Re-adding a collection to Ansible works the same as adding it in the first place. See the `process of adding a new collection to Ansible <https://github.com/ansible-community/ansible-build-data/#adding-a-new-collection>`_ for reference.
+
+#. Re-add collection to ``ansible.in`` (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/ansible.in``).
+#. Re-add collection to ``collection-meta.yaml`` (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/collection-meta.yaml``).
+#. If the removal was announced in the Ansible changelog for a version that has not yet been released (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``), remove the announcement.
+
 Broken collections
 ==================
 
@@ -36,12 +74,8 @@ Process
 
 The announcement mentioned below must state the reasons for the proposed removal and alert maintainers and the Ansible community that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
 
-#. Announce upcoming removal in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``).
-#. Announce upcoming removal in the collection's issue tracker.
-#. Announce upcoming removal in The Bullhorn.
-#. Remove from ``ansible.in`` for the next major version (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/ansible.in``).
-#. Remove form ``collection-meta.yaml`` for the next major release (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/collection-meta.yaml``).
-#. Once the first alpha of Ansible X+1 is to be released: document actual removal in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/changelog.yaml``).
+#. Announce upcoming removal in Ansible X+1 as described in :ref:`<announce_removal>`.
+#. Remove collection from Ansible X+1 as described in :ref:`<remove_collection>`.
 
 Cancelling removal of a broken collection
 -----------------------------------------
@@ -57,8 +91,7 @@ Process
 
 #. Update the removal issue in the collection's issue tracker, and close the issue.
 #. Announce cancelled removal in The Bullhorn.
-#. Re-add collection to ``ansible.in`` for the next major release (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/ansible.in``).
-#. Re-add collection to ``collection-meta.yaml`` for the next major release (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/collection-meta.yaml``).
+#. Re-add collection to Ansible X+1 as described in :ref:`readd_collection`.
 
 Re-adding collection to Ansible
 -------------------------------
@@ -100,12 +133,8 @@ Process
 #. At least four weeks after the notice appeared in The Bullhorn and the collection's issue tracker, the Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. The vote must be open for at least one week.
 #. If the SC does not votes that the collection seems to be unmaintained, the process is stopped. The issue needs to be updated accordingly.
 #. If X.0.0 will be released next, set Y=X+1. If X.0.0 has already been released, but (X+1).0.0 has not yet been released, set Y=X+2.
-#. Announce upcoming removal from Ansible Y in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``).
-#. Announce upcoming removal from Ansible Y in the collection's issue tracker.
-#. Announce upcoming removal from Ansible Y in The Bullhorn.
-#. Remove from ``ansible.in`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/ansible.in``).
-#. Remove form ``collection-meta.yaml`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/collection-meta.yaml``).
-#. Once the first alpha of Ansible Y is to be released: document actual removal in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/changelog.yaml``).
+#. Announce upcoming removal from Ansible Y as described in :ref:`<announce_removal>`.
+#. Remove collection from Ansible Y as described in :ref:`<remove_collection>`.
 
 Cancelling removal of an unmaintained collection
 ------------------------------------------------
@@ -123,8 +152,7 @@ Process
 #. The Steering Committee votes on whether the result is acceptable.
 #. A negative vote must come with a good explanation why the clean up work has not been sufficient. In that case, this process stops.
 #. If the Steering Committee does not vote against still removing the collection (this includes the case that the vote did not reach quorum), proceed as follows.
-#. Re-add collection to ``ansible.in`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/ansible.in``).
-#. Re-add collection to ``collection-meta.yaml`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/collection-meta.yaml``).
+#. Re-add collection to Ansible Y as described in :ref:`readd_collection`.
 
 Re-adding collection to Ansible
 -------------------------------

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -7,21 +7,28 @@ Ansible Community Package Collections Removal Process
 Overview
 ========
 
-This document describes under which circumstances collections can be removed from the `Ansible community package <https://pypi.org/project/ansible/>`_ (`build data <https://github.com/ansible-community/ansible-build-data/>`_).
+Sometimes the Ansible community removes a collection from the Ansible package. We try to do this only rarely. This document describes why we might remove a collection from the `Ansible community package <https://pypi.org/project/ansible/>`_ (`build data <https://github.com/ansible-community/ansible-build-data/>`_).
 
-Right now this document tries to set up some first processes. In cases of emergency the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions, but the goal is to only use processes documented in here.
+In cases of emergency (for example, a serious security vulnerability that is not fixed in a collection) the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions. In most cases, we follow the rules listed on this page.
 
-Broken collections
-==================
+Reasons to remove a collection
+==============================
 
-A collection is considered broken if one of the following conditions is true:
+
+Collection is broken
+--------------------
+
+The community can remove a collection from the Ansible community package if the collection is broken. A collection is considered broken if one of the following conditions is true:
 
 #. It depends on another collection included in X.0.0 but does not work with the actual version of it that is included, and there is no content in the collection that still works.
 
 If the collection is broken, it can be removed from Ansible (X+1).0.0 under the following conditions:
 
-#. The collection seems to be unmaintained and nobody successfully manages to fix the problems.
-#. The imminent removal in the next major Ansible release and its reasons are announced in the Ansible changelog, in The Bullhorn, and in the collection's issue tracker at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release. The announcement must also contain information that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
+#. The collection seems to be unmaintained and nobody fixes the problems.
+#. The plan to remove the collection in the next major Ansible release is publicized at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release. The removal must be announced in multiple places:
+- included in the Ansible changelog
+- announced in The Bullhorn
+The announcement must state the reasons for the proposed removal and alert maintainers and the Ansible community that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
 
 Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
 
@@ -33,8 +40,8 @@ Conditions under which the collections can be re-included in the Ansible package
 #. The issues have to be fixed and a new release has to be made before the Ansible X+2 feature freeze.
 #. Someone has to promise to maintain the collection and prevent a similar situation at least for some time.
 
-Unmaintained collections
-========================
+Collection is unmaintained
+--------------------------
 
 A collection is considered unmaintained if multiple of the following conditions are satisfied:
 
@@ -42,10 +49,10 @@ A collection is considered unmaintained if multiple of the following conditions 
 #. CI has stopped passing (or even has not been running) for several months.
 #. Bug reports and bugfix PRs start piling up without being reviewed.
 
-There is no complete formal definition of what it means that a collection is considered unmaintained. To start the process of removing an unmaintained collection, the following has to be done in the following order:
+There is no complete formal definition of an unmaintained collection. To start the process of removing an unmaintained collection, the following must be done in the following order:
 
 #. The appearance that the collection is no longer maintained and might be removed from the Ansible package has to be announced both in The Bullhorn and in the collection's issue tracker.
-#. The Ansible Community Engineering Steering Committee (SC) has to look at the collection and vote that it considers it unmaintained. This must happen at least four weeks after the notice has appeared in the collection's issue tracker and in The Bullhorn, and the vote must be open for at least one week.
+#. The Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. This must happen at least four weeks after the notice has appeared in the collection's issue tracker and in The Bullhorn, and the vote must be open for at least one week.
 #. If the SC votes that the collection seems to unmaintained, another announcement is made in the collection's issue tracker, in The Bullhorn, and in the Ansible changelog that it will be removed from Ansible Y release. Here Y must be X+1 if Ansible X.0.0 will be released next, or Y must be X+2 if Ansible X.0.0 has already been released. This means that the announcement of impending removal will be active for at least one major release cycle of Ansible.
 
 Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -7,32 +7,36 @@ Ansible Community Package Collections Removal Process
 Overview
 ========
 
-This document describes under which circumstances collections can be removed from the `Ansible community package <https://pypi.org/project/ansible/>`_ (`build data <https://github.com/ansible-community/ansible-build-data/>`_). Right now this document tries to set up some first processes. In cases of emergency the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions, but the goal is to only use processes documented in here.
+This document describes under which circumstances collections can be removed from the `Ansible community package <https://pypi.org/project/ansible/>`_ (`build data <https://github.com/ansible-community/ansible-build-data/>`_).
 
-Removing broken collections
-===========================
+Right now this document tries to set up some first processes. In cases of emergency the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions, but the goal is to only use processes documented in here.
+
+Broken collections
+==================
 
 If it turns out that a collection contained in Ansible X.0.0 depends on another collection included in X.0.0 and does not work with it, the collection can be removed from Ansible (X+1).0.0 under the following conditions:
 
-1. The collection seems to be unmaintained, and nobody successfully manages to fix the problems.
-2. The imminent removal in the next major Ansible release is announced in the Ansible changelog, in The Bullhorn, and in the collection's issue tracker at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release.
+1. The collection seems to be unmaintained and nobody successfully manages to fix the problems.
+2. The imminent removal in the next major Ansible release and its reasons are announced in the Ansible changelog, in The Bullhorn, and in the collection's issue tracker at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release. The announcement must also contain information that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
 
 Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
 
-1. The issues have to be fixed and a new release (bugfix, minor or major) has to be made before the Ansible X+1 feature freeze. Also someone has to promise to maintain the collection and prevent a similar situation at least for some time.
+#. The issues have to be fixed and a new release (bugfix, minor or major) has to be made before the Ansible X+1 feature freeze.
+#. Someone has to promise to maintain the collection and prevent a similar situation at least for some time.
 
-Conditions under which the collections can be re-included in the Ansible package without going through the full inclusion process (https://github.com/ansible-collections/ansible-inclusion/):
+Conditions under which the collections can be re-included in the Ansible package without going through the `full inclusion process <https://github.com/ansible-collections/ansible-inclusion/>`_:
 
-1. The issues have to be fixed and a new release has to be made before the Ansible X+2 feature freeze. Also someone has to promise to maintain the collection and prevent a similar situation at least for some time.
+#. The issues have to be fixed and a new release has to be made before the Ansible X+2 feature freeze.
+#. Someone has to promise to maintain the collection and prevent a similar situation at least for some time.
 
-Removing unmaintained collections
-=================================
+Unmaintained collections
+========================
 
 A collection is considered unmaintained if multiple of the following conditions are satisfied:
 
-1. There has been no activity in the collection repository for several months.
-2. CI has stopped passing (or even has not been running) for several months.
-3. Bug reports and bugfix PRs start piling up without being reviewed or merged.
+#. There has been no maintainer's activity in the collection repository for several months (for example, pull request merges and releases).
+#. CI has stopped passing (or even has not been running) for several months.
+#. Bug reports and bugfix PRs start piling up without being reviewed.
 
 There is no complete formal definition of what it means that a collection is considered unmaintained. To start the process of removing an unmaintained collection, the following has to be done in the following order:
 
@@ -42,6 +46,8 @@ There is no complete formal definition of what it means that a collection is con
 
 Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
 
-1. One or multiple maintainers step up, or return, to clean up the collection's state. The Steering Committee will vote on whether the result is acceptable. A negative vote must come with a good explanation why the clean up work has not been sufficient.
+#. One or multiple maintainers step up, or return, to clean up the collection's state.
+#. There have been concrete results made by new maintainers (for example, CI has been fixed, the collection has been released, pull request authors have got meaningful feedback).
+#. The Steering Committee votes on whether the result is acceptable. A negative vote must come with a good explanation why the clean up work has not been sufficient.
 
 Once the collection has been removed from Ansible Y.0.0, it needs to go through the full inclusion process to be re-added to the Ansible package. Exceptions are only possible if the Steering Committee votes on them, and it is in the discretion of the Steering Committee to deny a fast re-entry without going through the full review process.

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -7,7 +7,7 @@ Ansible Community Package Collections Removal Process
 Overview
 ========
 
-Sometimes the Ansible community removes a collection from the Ansible package. We try to do this only rarely. This document describes why we might remove a collection from the `Ansible community package <https://pypi.org/project/ansible/>`_ (`build data <https://github.com/ansible-community/ansible-build-data/>`_).
+Sometimes the Ansible community removes a collection from the Ansible package for stability, legal, or security reasons. This document describes why we might remove a collection from the `Ansible community package <https://pypi.org/project/ansible/>`_ (`build data <https://github.com/ansible-community/ansible-build-data/>`_).
 
 In cases of emergency (for example, a serious security vulnerability that is not fixed in a collection) the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions. In most cases, we follow the rules listed on this page.
 

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -74,8 +74,8 @@ Process
 
 The announcement mentioned below must state the reasons for the proposed removal and alert maintainers and the Ansible community that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
 
-#. Announce upcoming removal in Ansible X+1 as described in :ref:`<announce_removal>`.
-#. Remove collection from Ansible X+1 as described in :ref:`<remove_collection>`.
+#. Announce upcoming removal in Ansible X+1 as described in :ref:`announce_removal`.
+#. Remove collection from Ansible X+1 as described in :ref:`remove_collection`.
 
 Cancelling removal of a broken collection
 -----------------------------------------
@@ -133,8 +133,8 @@ Process
 #. At least four weeks after the notice appeared in The Bullhorn and the collection's issue tracker, the Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. The vote must be open for at least one week.
 #. If the SC does not votes that the collection seems to be unmaintained, the process is stopped. The issue needs to be updated accordingly.
 #. If X.0.0 will be released next, set Y=X+1. If X.0.0 has already been released, but (X+1).0.0 has not yet been released, set Y=X+2.
-#. Announce upcoming removal from Ansible Y as described in :ref:`<announce_removal>`.
-#. Remove collection from Ansible Y as described in :ref:`<remove_collection>`.
+#. Announce upcoming removal from Ansible Y as described in :ref:`announce_removal`.
+#. Remove collection from Ansible Y as described in :ref:`remove_collection`.
 
 Cancelling removal of an unmaintained collection
 ------------------------------------------------

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -11,37 +11,79 @@ Sometimes the Ansible community removes a collection from the Ansible package. W
 
 In cases of emergency (for example, a serious security vulnerability that is not fixed in a collection) the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions. In most cases, we follow the rules listed on this page.
 
-Reasons to remove a collection
-==============================
+Broken collections
+==================
 
+The community can remove a collection from the Ansible community package if the collection is broken.
 
-Collection is broken
---------------------
+Identifying and removing a broken collection
+--------------------------------------------
 
-The community can remove a collection from the Ansible community package if the collection is broken. A collection is considered broken if one of the following conditions is true:
+Conditions for removal
+~~~~~~~~~~~~~~~~~~~~~~
+
+A collection is considered broken if one of the following conditions is true:
 
 #. It depends on another collection included in X.0.0 but does not work with the actual version of it that is included, and there is no content in the collection that still works.
 
 We remove broken collections from Ansible (X+1).0.0 under the following conditions:
 
 #. The collection seems to be unmaintained and nobody fixes the problems.
-#. The plan to remove the collection in the next major Ansible release is publicized at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release. The removal must be announced in multiple places:
-- included in the Ansible changelog
-- announced in The Bullhorn
-The announcement must state the reasons for the proposed removal and alert maintainers and the Ansible community that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
+#. The plan to remove the collection in the next major Ansible release is publicized at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release (feature freeze).
 
-Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
+Process
+~~~~~~~
+
+The announcement mentioned below must state the reasons for the proposed removal and alert maintainers and the Ansible community that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
+
+#. Announce upcoming removal in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``).
+#. Announce upcoming removal in the collection's issue tracker.
+#. Announce upcoming removal in The Bullhorn.
+#. Remove from ``ansible.in`` for the next major version (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/ansible.in``).
+#. Remove form ``collection-meta.yaml`` for the next major release (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/collection-meta.yaml``).
+#. Once the first alpha of Ansible X+1 is to be released: document actual removal in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/changelog.yaml``).
+
+Cancelling removal of a broken collection
+-----------------------------------------
+
+Conditions
+~~~~~~~~~~
 
 #. The issues have to be fixed and a new release (bugfix, minor or major) has to be made before the Ansible X+1 feature freeze.
 #. Someone has to promise to maintain the collection and prevent a similar situation at least for some time.
+
+Process
+~~~~~~~
+
+#. Update the removal issue in the collection's issue tracker, and close the issue.
+#. Announce cancelled removal in The Bullhorn.
+#. Re-add collection to ``ansible.in`` for the next major release (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/ansible.in``).
+#. Re-add collection to ``collection-meta.yaml`` for the next major release (``https://github.com/ansible-community/ansible-build-data/blob/main/<X+1>/collection-meta.yaml``).
+
+Re-adding collection to Ansible
+-------------------------------
+
+Conditions
+~~~~~~~~~~
 
 Conditions under which the collections can be re-included in the Ansible package without going through the `full inclusion process <https://github.com/ansible-collections/ansible-inclusion/>`_:
 
 #. The issues have to be fixed and a new release has to be made before the Ansible X+2 feature freeze.
 #. Someone has to promise to maintain the collection and prevent a similar situation at least for some time.
 
-Collection is unmaintained
---------------------------
+Process
+~~~~~~~
+
+#. Follow regular process of adding a new collection to Ansible.
+
+Unmaintained collections
+========================
+
+Identifying and removing an unmaintained collection
+---------------------------------------------------
+
+Conditions for removal
+~~~~~~~~~~~~~~~~~~~~~~
 
 A collection is considered unmaintained if multiple of the following conditions are satisfied:
 
@@ -49,16 +91,42 @@ A collection is considered unmaintained if multiple of the following conditions 
 #. CI has stopped passing (or even has not been running) for several months.
 #. Bug reports and bugfix PRs start piling up without being reviewed.
 
-There is no complete formal definition of an unmaintained collection. To start the process of removing an unmaintained collection, the following must be done in the following order:
+There is no complete formal definition of an unmaintained collection.
+
+Process
+~~~~~~~
 
 #. The appearance that the collection is no longer maintained and might be removed from the Ansible package has to be announced both in The Bullhorn and in the collection's issue tracker.
-#. The Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. This must happen at least four weeks after the notice has appeared in the collection's issue tracker and in The Bullhorn, and the vote must be open for at least one week.
-#. If the SC votes that the collection seems to unmaintained, another announcement is made in the collection's issue tracker, in The Bullhorn, and in the Ansible changelog that it will be removed from Ansible Y release. Here Y must be X+1 if Ansible X.0.0 will be released next, or Y must be X+2 if Ansible X.0.0 has already been released. This means that the announcement of impending removal will be active for at least one major release cycle of Ansible.
+#. At least four weeks after the notice appeared in The Bullhorn and the collection's issue tracker, the Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. The vote must be open for at least one week.
+#. If the SC does not votes that the collection seems to be unmaintained, the process is stopped. The issue needs to be updated accordingly.
+#. If X.0.0 will be released next, set Y=X+1. If X.0.0 has already been released, but (X+1).0.0 has not yet been released, set Y=X+2.
+#. Announce upcoming removal from Ansible Y in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``).
+#. Announce upcoming removal from Ansible Y in the collection's issue tracker.
+#. Announce upcoming removal from Ansible Y in The Bullhorn.
+#. Remove from ``ansible.in`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/ansible.in``).
+#. Remove form ``collection-meta.yaml`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/collection-meta.yaml``).
+#. Once the first alpha of Ansible Y is to be released: document actual removal in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/changelog.yaml``).
 
-Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
+Cancelling removal of an unmaintained collection
+------------------------------------------------
 
+Conditions
+~~~~~~~~~~
+
+#. Ansible Y has not yet been released.
 #. One or multiple maintainers step up, or return, to clean up the collection's state.
 #. There have been concrete results made by new maintainers (for example, CI has been fixed, the collection has been released, pull request authors have got meaningful feedback).
-#. The Steering Committee votes on whether the result is acceptable. A negative vote must come with a good explanation why the clean up work has not been sufficient.
 
-Once the collection has been removed from Ansible Y.0.0, it needs to go through the full inclusion process to be re-added to the Ansible package. Exceptions are only possible if the Steering Committee votes on them, and it is in the discretion of the Steering Committee to deny a fast re-entry without going through the full review process.
+Process
+~~~~~~~
+
+#. The Steering Committee votes on whether the result is acceptable.
+#. A negative vote must come with a good explanation why the clean up work has not been sufficient. In that case, this process stops.
+#. If the Steering Committee does not vote against still removing the collection (this includes the case that the vote did not reach quorum), proceed as follows.
+#. Re-add collection to ``ansible.in`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/ansible.in``).
+#. Re-add collection to ``collection-meta.yaml`` for Ansible Y (``https://github.com/ansible-community/ansible-build-data/blob/main/<Y>/collection-meta.yaml``).
+
+Re-adding collection to Ansible
+-------------------------------
+
+There is no simplified process. Once the collection has been removed from Ansible Y.0.0, it needs to go through the full inclusion process to be re-added to the Ansible package. Exceptions are only possible if the Steering Committee votes on them, and it is in the discretion of the Steering Committee to deny a fast re-entry without going through the full review process.

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -16,7 +16,7 @@ General processes
 
 This section describes some general processes that will be referred to below.
 
-_announce_removal:
+.. _announce_removal:
 
 Announcing upcoming removal
 ---------------------------
@@ -26,7 +26,7 @@ Announcing upcoming removal
 #. Announce upcoming removal in the collection's issue tracker.
 #. Announce upcoming removal in The Bullhorn.
 
-_remove_collection:
+.. _remove_collection:
 
 Removing a collection
 ---------------------
@@ -38,7 +38,7 @@ To remove a collection from Ansible version X.0.0:
 #. Document actual removal for the first/next alpha of Ansible X.0.0 in the Ansible changelog (``https://github.com/ansible-community/ansible-build-data/blob/main/<X>/changelog.yaml``).
    See the following link for an `example on how to add changelog entries to the Ansible changelog <https://github.com/ansible-community/ansible-build-data/pull/68/files>`__.
 
-_readd_collection:
+.. _readd_collection:
 
 Re-adding a collection
 ----------------------

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -1,0 +1,47 @@
+*****************************************************
+Ansible Community Package Collections Removal Process
+*****************************************************
+
+.. contents:: Topics
+
+Overview
+========
+
+This document describes under which circumstances collections can be removed from the `Ansible community package <https://pypi.org/project/ansible/>`_ (`build data <https://github.com/ansible-community/ansible-build-data/>`_). Right now this document tries to set up some first processes. In cases of emergency the `Ansible Community Engineering Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ can vote on emergency exceptions, but the goal is to only use processes documented in here.
+
+Removing broken collections
+===========================
+
+If it turns out that a collection contained in Ansible X.0.0 depends on another collection included in X.0.0 and does not work with it, the collection can be removed from Ansible (X+1).0.0 under the following conditions:
+
+1. The collection seems to be unmaintained, and nobody successfully manages to fix the problems.
+2. The imminent removal in the next major Ansible release is announced in the Ansible changelog, in The Bullhorn, and in the collection's issue tracker at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release.
+
+Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
+
+1. The issues have to be fixed and a new release (bugfix, minor or major) has to be made before the Ansible X+1 feature freeze. Also someone has to promise to maintain the collection and prevent a similar situation at least for some time.
+
+Conditions under which the collections can be re-included in the Ansible package without going through the full inclusion process (https://github.com/ansible-collections/ansible-inclusion/):
+
+1. The issues have to be fixed and a new release has to be made before the Ansible X+2 feature freeze. Also someone has to promise to maintain the collection and prevent a similar situation at least for some time.
+
+Removing unmaintained collections
+=================================
+
+A collection is considered unmaintained if multiple of the following conditions are satisfied:
+
+1. There has been no activity in the collection repository for several months.
+2. CI has stopped passing (or even has not been running) for several months.
+3. Bug reports and bugfix PRs start piling up without being reviewed or merged.
+
+There is no complete formal definition of what it means that a collection is considered unmaintained. To start the process of removing an unmaintained collection, the following has to be done in the following order:
+
+1. The appearance that the collection is no longer maintained and might be removed from the Ansible package has to be announced both in The Bullhorn and in the collection's issue tracker.
+2. The Ansible Community Engineering Steering Committee (SC) has to look at the collection and vote that it considers it unmaintained. This must happen at least four weeks after the notice has appeared in the collection's issue tracker and in The Bullhorn, and the vote must be open for at least one week.
+3. If the SC votes that the collection seems to unmaintained, another announcement is made in the collection's issue tracker, in The Bullhorn, and in the Ansible changelog that it will be removed from Ansible Y release. Here Y must be X+1 if Ansible X.0.0 will be released next, or Y must be X+1 if Ansible X.0.0 has already been released. This means that the announcement of impending removal will be active for at least one major release cycle of Ansible.
+
+Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
+
+1. One or multiple maintainers step up, or return, to clean up the collection's state. The Steering Committee will vote on whether the result is acceptable. A negative vote must come with a good explanation why the clean up work has not been sufficient.
+
+Once the collection has been removed from Ansible Y.0.0, it needs to go through the full inclusion process to be re-added to the Ansible package. Exceptions are only possible if the Steering Committee votes on them, and it is in the discretion of the Steering Committee to deny a fast re-entry without going through the full review process.

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -138,7 +138,7 @@ Process
 
 #. The appearance that the collection is no longer maintained and might be removed from the Ansible package has to be announced both in The Bullhorn and in the collection's issue tracker.
 #. At least four weeks after the notice appeared in The Bullhorn and the collection's issue tracker, the Ansible Community Engineering Steering Committee (SC) must look at the collection and vote that it considers it unmaintained. The vote must be open for at least one week.
-#. If the SC does not votes that the collection seems to be unmaintained, the process is stopped. The issue needs to be updated accordingly.
+#. If the SC does not vote that the collection seems to be unmaintained, the process is stopped. The issue needs to be updated accordingly.
 #. If X.0.0 will be released next, set Y=X+1. If X.0.0 has already been released, but (X+1).0.0 has not yet been released, set Y=X+2.
 #. `Announce upcoming removal from Ansible Y <announce_removal_>`_.
 #. `Remove collection from Ansible Y <remove_collection_>`_.

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -1,4 +1,4 @@
-.. _removal_from_ansible::
+.. _removal_from_ansible:
 
 *****************************************************
 Ansible Community Package Collections Removal Process

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -89,7 +89,7 @@ Conditions
 Process
 ~~~~~~~
 
-#. Update the removal issue in the collection's issue tracker, and close the issue.
+#. Update the removal issue in the collection's issue tracker and close the issue.
 #. Announce cancelled removal in The Bullhorn.
 #. Re-add collection to Ansible X+1 as described in :ref:`readd_collection`.
 
@@ -107,7 +107,7 @@ Conditions under which the collections can be re-included in the Ansible package
 Process
 ~~~~~~~
 
-#. Follow regular process of adding a new collection to Ansible.
+#. Follow `regular process of adding a new collection to Ansible <https://github.com/ansible-community/ansible-build-data/#adding-a-new-collection>`_.
 
 Unmaintained collections
 ========================

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -1,3 +1,5 @@
+.. _removal_from_ansible::
+
 *****************************************************
 Ansible Community Package Collections Removal Process
 *****************************************************
@@ -14,7 +16,12 @@ In cases of emergency (for example, a serious security vulnerability that is not
 General processes
 =================
 
-This section describes some general processes that will be referred to below.
+The general process of removing a collection follows these steps:
+
+#. announcing an upcoming removal of a collection
+#. removing the collection
+#. when appropriate, re-adding the collection
+
 
 .. _announce_removal:
 

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -14,10 +14,14 @@ Right now this document tries to set up some first processes. In cases of emerge
 Broken collections
 ==================
 
-If it turns out that a collection contained in Ansible X.0.0 depends on another collection included in X.0.0 and does not work with it, the collection can be removed from Ansible (X+1).0.0 under the following conditions:
+A collection is considered broken if one of the following conditions is true:
 
-1. The collection seems to be unmaintained and nobody successfully manages to fix the problems.
-2. The imminent removal in the next major Ansible release and its reasons are announced in the Ansible changelog, in The Bullhorn, and in the collection's issue tracker at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release. The announcement must also contain information that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
+#. It depends on another collection included in X.0.0 but does not work with the actual version of it that is included, and there is no content in the collection that still works.
+
+If the collection is broken, it can be removed from Ansible (X+1).0.0 under the following conditions:
+
+#. The collection seems to be unmaintained and nobody successfully manages to fix the problems.
+#. The imminent removal in the next major Ansible release and its reasons are announced in the Ansible changelog, in The Bullhorn, and in the collection's issue tracker at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release. The announcement must also contain information that, to prevent the removal, the collection urgently needs new maintainers who can fix the problems.
 
 Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
 
@@ -40,9 +44,9 @@ A collection is considered unmaintained if multiple of the following conditions 
 
 There is no complete formal definition of what it means that a collection is considered unmaintained. To start the process of removing an unmaintained collection, the following has to be done in the following order:
 
-1. The appearance that the collection is no longer maintained and might be removed from the Ansible package has to be announced both in The Bullhorn and in the collection's issue tracker.
-2. The Ansible Community Engineering Steering Committee (SC) has to look at the collection and vote that it considers it unmaintained. This must happen at least four weeks after the notice has appeared in the collection's issue tracker and in The Bullhorn, and the vote must be open for at least one week.
-3. If the SC votes that the collection seems to unmaintained, another announcement is made in the collection's issue tracker, in The Bullhorn, and in the Ansible changelog that it will be removed from Ansible Y release. Here Y must be X+1 if Ansible X.0.0 will be released next, or Y must be X+1 if Ansible X.0.0 has already been released. This means that the announcement of impending removal will be active for at least one major release cycle of Ansible.
+#. The appearance that the collection is no longer maintained and might be removed from the Ansible package has to be announced both in The Bullhorn and in the collection's issue tracker.
+#. The Ansible Community Engineering Steering Committee (SC) has to look at the collection and vote that it considers it unmaintained. This must happen at least four weeks after the notice has appeared in the collection's issue tracker and in The Bullhorn, and the vote must be open for at least one week.
+#. If the SC votes that the collection seems to unmaintained, another announcement is made in the collection's issue tracker, in The Bullhorn, and in the Ansible changelog that it will be removed from Ansible Y release. Here Y must be X+1 if Ansible X.0.0 will be released next, or Y must be X+2 if Ansible X.0.0 has already been released. This means that the announcement of impending removal will be active for at least one major release cycle of Ansible.
 
 Conditions under which the collection can stay in the Ansible package before removal in Ansible X+1:
 

--- a/removal_from_ansible.rst
+++ b/removal_from_ansible.rst
@@ -22,7 +22,7 @@ The community can remove a collection from the Ansible community package if the 
 
 #. It depends on another collection included in X.0.0 but does not work with the actual version of it that is included, and there is no content in the collection that still works.
 
-If the collection is broken, it can be removed from Ansible (X+1).0.0 under the following conditions:
+We remove broken collections from Ansible (X+1).0.0 under the following conditions:
 
 #. The collection seems to be unmaintained and nobody fixes the problems.
 #. The plan to remove the collection in the next major Ansible release is publicized at least two months before the (X+1).0.0 release, and at least one month before the first (X+1).0.0 beta release. The removal must be announced in multiple places:


### PR DESCRIPTION
##### SUMMARY
I wrote this up based on the discussion we had at today's community meeting. The aim of this PR is to have some basic rules on which collections can be removed so we can vote on them soon and establish them. The aim is **not** to have a complete list of rules. I expect we will have more discussions and additional situations added to this document in follow-up PRs.

The two processes described here are modelled after two explicit examples:

1. community.kubevirt is currently broken and does not work as inclued in Ansible 5, since it requires community.kubernetes < 2.0.0, while Ansible 5 includes community.kubernetes >= 2.0.0. Adjusting the collection to community.kubernetes >= 2.0.0 or kubernetes.core >= 2.0.0 have been unsuccessful and stagnated (https://github.com/ansible-collections/community.kubevirt/pull/34 has been inactive for six months now). Since more breakage could happen with kubernetes.core 3.0.0, we do not want to keep this collection in Ansible without active maintainers who promise to keep the code working with current versions. The first of the two processes will apply to this collection.

2. community.google seems to be unmaintained. It is unclear whether it still works (there is no indication it does, but also no indication that it does not). It uses very old and outdated dependencies, and CI has been broken for a long time before it was automatically disabled months ago. (The broken part was sanity checks only, unit tests were passing.) Since there has been no community interaction on this for a long time (there is no issue except some generic announcements, and there are no PRs), and there has never been any real community work on this collection, it is more likely that nobody is using it and it might even be totally broken without anyone realizing. The second process is written with this collection in mind. It gives community and users of this collection a chance to say that they use it and to step up helping it, but if nobody does, we have a process to remove it. (Also if it is removed folks can still manually install it.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
removal_from_ansible.rst
