### PR TITLE
Make it clear that code outside plugins/ can have other free software licenses as well

### DIFF
--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -253,11 +253,11 @@ ways:
                <https://opensource.org/licenses/BSD-2-Clause>`_ license to make it possible for
                third-party modules which are licensed incompatibly with the GPLv3 to use them.
                Please consider this use case when licensing your own ``module_utils``.
-:Code outside plugins/: Code outside `plugins/`, in particular unit tests, must be licensed with
-                        a free software license that is compatible with the
-                       `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
-                       Note that such code that imports GPL licensed code must be GPL licensed
-                       itself as well.
+:Code outside ``plugins/``: Code outside ``plugins/``, in particular unit tests, must be licensed with
+                            a free software license that is compatible with the
+                            `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
+                            Note that such code that imports GPL licensed code must be GPL licensed
+                            itself as well.
 :All other code: All other code must be under the `GPL-3.0-or-later
                  <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins are run
                  inside of the Ansible controller process which is licensed under the GPLv3+ and

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -263,7 +263,9 @@ ways:
                  `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_,
                  provided that such code does not import any other code that is licensed under
                  the ``GPL-3.0-or-later``. If the file does import other ``GPL-3.0-or-later`` code,
-                 then it must similarly be licensed under ``GPL-3.0-or-later``.
+                 then it must similarly be licensed under ``GPL-3.0-or-later``. Note that unit tests
+                 often import code from ansible-core, plugins, module utils, or modules, and such code
+                 is often licensed under ``GPL-3.0-or-later``.
 :Non code content: At the moment, these must also be under the `GPL-3.0-or-later       
                    <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
 

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -256,8 +256,8 @@ ways:
 :All other code in ``plugins/``: All other code in ``plugins/`` must be under the `GPL-3.0-or-later
                                  <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins
                                  are run inside of the Ansible controller process which is licensed under
-                                 the ``GPL-3.0-or-later`` and often must import code from the controller.  For these
-                                 reasons, the GPLv3+ must be used.
+                                 the ``GPL-3.0-or-later`` and often must import code from the controller.
+                                 For these reasons, the GPLv3+ must be used.
 :All other code: Code outside ``plugins/``, in particular unit tests, may be licensed under
                  another free software license that is compatible with the
                  `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_,

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -253,17 +253,17 @@ ways:
                <https://opensource.org/licenses/BSD-2-Clause>`_ license to make it possible for
                third-party modules which are licensed incompatibly with the GPLv3 to use them.
                Please consider this use case when licensing your own ``module_utils``.
-:Code outside ``plugins/``: Code outside ``plugins/``, in particular unit tests, must be licensed with
-                            a free software license that is compatible with the
-                            `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
-                            Note that such code that imports GPL licensed code must be GPL licensed
-                            itself as well.
-:All other code: All other code must be under the `GPL-3.0-or-later
-                 <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins are run
-                 inside of the Ansible controller process which is licensed under the GPLv3+ and
-                 often must import code from the controller.  For these reasons, the GPLv3+ must be
-                 used.
-:Non code content: At the moment, these must also be under the `GPL-3.0-or-later
+:All other code in ``plugins/``: All other code in ``plugins/`` must be under the `GPL-3.0-or-later
+                                 <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins
+                                 are run inside of the Ansible controller process which is licensed under
+                                 the GPLv3+ and often must import code from the controller.  For these
+                                 reasons, the GPLv3+ must be used.
+:All other code: Code outside ``plugins/``, in particular unit tests, must be licensed with
+                 a free software license that is compatible with the
+                 `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
+                 Note that such code that imports GPL licensed code must be GPL licensed
+                 itself as well.
+:Non code content: At the moment, these must also be under the `GPL-3.0-or-later       
                    <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
 
 Use `this table of licenses from the Fedora Project

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -253,6 +253,11 @@ ways:
                <https://opensource.org/licenses/BSD-2-Clause>`_ license to make it possible for
                third-party modules which are licensed incompatibly with the GPLv3 to use them.
                Please consider this use case when licensing your own ``module_utils``.
+:Code outside plugins/: Code outside `plugins/`, in particular unit tests, must be licensed with
+                        a free software license that is compatible with the
+                       `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
+                       Note that such code that imports GPL licensed code must be GPL licensed
+                       itself as well.
 :All other code: All other code must be under the `GPL-3.0-or-later
                  <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins are run
                  inside of the Ansible controller process which is licensed under the GPLv3+ and

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -258,11 +258,12 @@ ways:
                                  are run inside of the Ansible controller process which is licensed under
                                  the GPLv3+ and often must import code from the controller.  For these
                                  reasons, the GPLv3+ must be used.
-:All other code: Code outside ``plugins/``, in particular unit tests, must be licensed with
-                 a free software license that is compatible with the
-                 `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
-                 Note that such code that imports GPL licensed code must be GPL licensed
-                 itself as well.
+:All other code: Code outside ``plugins/``, in particular unit tests, may be licensed under
+                 another free software license that is compatible with the
+                 `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_,
+                 provided that such code that does not import any other code that is licensed under
+                 the ``GPL-3.0-or-later``. If the file does import other ``GPL-3.0-or-later`` code,
+                 then it must similarly be licensed under ``GPL-3.0-or-later``.
 :Non code content: At the moment, these must also be under the `GPL-3.0-or-later       
                    <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
 

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -256,7 +256,7 @@ ways:
 :All other code in ``plugins/``: All other code in ``plugins/`` must be under the `GPL-3.0-or-later
                                  <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins
                                  are run inside of the Ansible controller process which is licensed under
-                                 the GPLv3+ and often must import code from the controller.  For these
+                                 the ``GPL-3.0-or-later`` and often must import code from the controller.  For these
                                  reasons, the GPLv3+ must be used.
 :All other code: Code outside ``plugins/``, in particular unit tests, may be licensed under
                  another free software license that is compatible with the

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -261,7 +261,7 @@ ways:
 :All other code: Code outside ``plugins/``, in particular unit tests, may be licensed under
                  another free software license that is compatible with the
                  `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_,
-                 provided that such code that does not import any other code that is licensed under
+                 provided that such code does not import any other code that is licensed under
                  the ``GPL-3.0-or-later``. If the file does import other ``GPL-3.0-or-later`` code,
                  then it must similarly be licensed under ``GPL-3.0-or-later``.
 :Non code content: At the moment, these must also be under the `GPL-3.0-or-later       

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -257,7 +257,7 @@ ways:
                                  <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.  These plugins
                                  are run inside of the Ansible controller process which is licensed under
                                  the ``GPL-3.0-or-later`` and often must import code from the controller.
-                                 For these reasons, the GPLv3+ must be used.
+                                 For these reasons, ``GPL-3.0-or-later`` must be used.
 :All other code: Code outside ``plugins/`` may be licensed under another free software license that is compatible
                  with the `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_,
                  provided that such code does not import any other code that is licensed under

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -258,14 +258,13 @@ ways:
                                  are run inside of the Ansible controller process which is licensed under
                                  the ``GPL-3.0-or-later`` and often must import code from the controller.
                                  For these reasons, the GPLv3+ must be used.
-:All other code: Code outside ``plugins/``, in particular unit tests, may be licensed under
-                 another free software license that is compatible with the
-                 `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_,
+:All other code: Code outside ``plugins/`` may be licensed under another free software license that is compatible
+                 with the `GPL-3.0-or-later <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_,
                  provided that such code does not import any other code that is licensed under
                  the ``GPL-3.0-or-later``. If the file does import other ``GPL-3.0-or-later`` code,
-                 then it must similarly be licensed under ``GPL-3.0-or-later``. Note that unit tests
-                 often import code from ansible-core, plugins, module utils, or modules, and such code
-                 is often licensed under ``GPL-3.0-or-later``.
+                 then it must similarly be licensed under ``GPL-3.0-or-later``. Note that this applies in
+                 particular to unit tests; these often import code from ansible-core, plugins, module utils,
+                 or modules, and such code is often licensed under ``GPL-3.0-or-later``.
 :Non code content: At the moment, these must also be under the `GPL-3.0-or-later       
                    <https://www.gnu.org/licenses/gpl-3.0-standalone.html>`_.
 


### PR DESCRIPTION
##### SUMMARY
Right now, the rules state that *"[a]ll other code must be under the GPL-3.0-or-later"*. From the explanation it is clear that this sentence is about all other code in plugins/, but it is not formulated that way.

The current formulation implies for example that all unit tests, helper scripts, or code files included in roles, playbooks, or integration tests must be licensed under GPLv3+. Especially for unit tests this can be problematic; for example community.docker now vendors some code from Docker SDK for Python (Apache 2.0 licensed) including unit tests for that code. The unit tests are also licensed under Apache 2.0, but this would violate a strict interpretation of the inclusion requirements.

This PR proposes an improved formulation that makes it clear that other code **outside `plugins/`** can also use other licenses.

(Ref: https://github.com/ansible-collections/community.docker/pull/433#discussion_r933993684)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
inclusion requirements
