### PR TITLE
Clarify SCM and release requirements

### DIFF
--- a/collection_checklist.md
+++ b/collection_checklist.md
@@ -11,7 +11,7 @@ Note for reviewers: If you don't know how to check any of the points below, plea
 - [ ] has a policy of releasing, versioning and deprecation announced to contributors and users in some way
 - [ ] have a Code of Conduct (CoC) compatible with the [Ansible Code of Conduct (CoC)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
 - [ ] have a publicly available issue tracker that does not require a paid level of service to create an account or view issues
-- [ ] have a public SCM repository, releases of the collection are tagged in this repository
+- [ ] have a public git repository, releases of the collection are tagged in this repository
 
 **Standards and documentation:**
 - [ ] adheres to [semantic versioning](https://semver.org/)

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -280,9 +280,11 @@ licensing and legal concerns that may otherwise affect your code.
 Repository management
 =====================
 
-Every collection MUST have a public git repository and releases of the collection MUST be tagged in this repository.
+Every collection MUST have a public git repository. Releases of the collection MUST be tagged in said repository. This means that releases MUST be ``git tag``ed and that the tag name MUST exactly match the Galaxy version number. Tag names MAY have a ``v`` prefix, but a collection's tag names MUST have a consistent format from release to release.
 
-We are open to add more SCMs once our tooling supports them.
+Additionally, collection artifacts released to Galaxy MUST be built from the sources that are tagged in the collection's git repository as that release. Any changes made during the build process MUST be clearly documented so the collection artifact can be reproduced.
+
+We are open to allowing other SCM software once our tooling supports them.
 
 Branch name and configuration
 -----------------------------

--- a/collection_requirements.rst
+++ b/collection_requirements.rst
@@ -280,7 +280,9 @@ licensing and legal concerns that may otherwise affect your code.
 Repository management
 =====================
 
-Every collection MUST have a public SCM repository and releases of the collection MUST be tagged in this repository.
+Every collection MUST have a public git repository and releases of the collection MUST be tagged in this repository.
+
+We are open to add more SCMs once our tooling supports them.
 
 Branch name and configuration
 -----------------------------


### PR DESCRIPTION
##### SUMMARY

We require that all collections [MUST have a public SCM repository](https://github.com/ansible-collections/overview/blob/24343d3d7723adaf911f2fcc3a69d02bb713fa2a/collection_requirements.rst#repository-management).

Actually, most people will use git nowadays but in theory, they could use any obscure SCM as long as the repo is publicly available.

This means that we might have to deal with a SCM we don't know and our tooling doesn't support. Therefor, I suggest requiring git instead of generic SCM repositories.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
collection_checklist.md
collection_requirements.rst

##### ADDITIONAL INFORMATION
https://github.com/ansible-community/community-topics/issues/148#issuecomment-1277828717

cc @felixfontein 